### PR TITLE
Memperbarui templat AIV/IPTV

### DIFF
--- a/modules/twinklearv.js
+++ b/modules/twinklearv.js
@@ -547,7 +547,7 @@ Twinkle.arv.callback.evaluate = function(e) {
 
 					aivPage.getStatusElement().status('Adding new report...');
 					aivPage.setEditSummary('Reporting [[Special:Contributions/' + uid + '|' + uid + ']].' + Twinkle.getPref('summaryAd'));
-					aivPage.setAppendText('\n*{{' + (mw.util.isIPAddress(uid) ? 'IPvandal' : 'vandal') + '|' + (/=/.test(uid) ? '1=' : '') + uid + '}} &ndash; ' + reason);
+					aivPage.setAppendText('\n*{{' + (mw.util.isIPAddress(uid) ? 'IPvandal' : 'Penggunavandal') + '|' + (/=/.test(uid) ? '1=' : '') + uid + '}} &ndash; ' + reason);
 					aivPage.append();
 				});
 			});


### PR DESCRIPTION
Sejak kemarin saya membuat Templat:Penggunavandal di idwiki yang digunakan untuk melaporkan pengguna terdaftar di WP:AIV/Wikipedia:Intervensi pengurus terhadap vandalisme, sedangkan untuk Templat:vandal memiliki fungsi yang berbeda yaitu memperingati pengguna di halaman pembicaraan bukan untuk melaporkan.